### PR TITLE
AlarmManagerService: catch all exception when trying to send pending alarm intent

### DIFF
--- a/services/core/java/com/android/server/AlarmManagerService.java
+++ b/services/core/java/com/android/server/AlarmManagerService.java
@@ -2623,7 +2623,7 @@ class AlarmManagerService extends SystemService {
                         Alarm alarm = triggerList.get(i);
                         try {
                             alarm.operation.send();
-                        } catch (PendingIntent.CanceledException e) {
+                        } catch (Exception e) {
                             if (alarm.repeatInterval > 0) {
                                 // This IntentSender is no longer valid, but this
                                 // is a repeating alarm, so toss the hoser.


### PR DESCRIPTION
Inside a container environment the PendingIntent doesn't seem to be set
at all times. Leaving a NullPointerException unhandled here is rather bad
so we're catching it and processing it the same way as a canceled intent.