### PR TITLE
Revert "Permanently hide caption bar for freeform windows"

### DIFF
--- a/core/java/com/android/internal/widget/DecorCaptionView.java
+++ b/core/java/com/android/internal/widget/DecorCaptionView.java
@@ -342,7 +342,7 @@ public class DecorCaptionView extends ViewGroup implements View.OnTouchListener,
      **/
     private void updateCaptionVisibility() {
         // Don't show the caption if the window has e.g. entered full screen.
-        boolean invisible = /* isFillingScreen() || !mShow */ true;
+        boolean invisible = isFillingScreen() || !mShow;
         mCaption.setVisibility(invisible ? GONE : VISIBLE);
         mCaption.setOnTouchListener(this);
     }


### PR DESCRIPTION
This reverts commit 7dfe6253a6014e7fb2ab23c78c00be2b29653e77.

This contributes to #331 (https://github.com/anbox/anbox/issues/331) which will bring the caption as client side decoration of the SDL window back. As next step this then allows us to introduce a back button similar to how Chrome OS does it.