### PR TITLE
wm: AnboxPlatformServiceProxy: Update host with the window rotation state

### DIFF
--- a/services/core/java/com/android/server/wm/AnboxPlatformServiceProxy.java
+++ b/services/core/java/com/android/server/wm/AnboxPlatformServiceProxy.java
@@ -111,6 +111,12 @@ public final class AnboxPlatformServiceProxy {
             data.writeInt(0);
             data.writeInt(0);
         }
+        /*
+         * Update mRotation value from surface flinger as is,
+         * 0 (0 degree), 1 (90 degree), 2 (180 degree), 3 (270 degree)
+         * to process at host side
+         */
+        data.writeInt(mWm.mRotation);
     }
 
     /*


### PR DESCRIPTION
Include the mRotation value in the message passed to host.
The rotation state will let the host know the expected
screen orientation.

Signed-off-by: Khasim Syed Mohammed <khasim.mohammed@linaro.org>
Signed-off-by: Lee Jones <lee.jones@linaro.org>