### PR TITLE
disable FLAG_SECURE

### DIFF
--- a/services/core/java/com/android/server/wm/WindowManagerService.java
+++ b/services/core/java/com/android/server/wm/WindowManagerService.java
@@ -2332,20 +2332,21 @@ public class WindowManagerService extends IWindowManager.Stub
      * Returns whether screen capture is disabled for all windows of a specific user.
      */
     boolean isScreenCaptureDisabledLocked(int userId) {
-        Boolean disabled = mScreenCaptureDisabled.get(userId);
-        if (disabled == null) {
-            return false;
-        }
-        return disabled;
+//        Boolean disabled = mScreenCaptureDisabled.get(userId);
+//        if (disabled == null) {
+//            return false;
+//        }
+//        return disabled;
+	return false;
     }
 
     boolean isSecureLocked(WindowState w) {
-        if ((w.mAttrs.flags&WindowManager.LayoutParams.FLAG_SECURE) != 0) {
-            return true;
-        }
-        if (isScreenCaptureDisabledLocked(UserHandle.getUserId(w.mOwnerUid))) {
-            return true;
-        }
+//        if ((w.mAttrs.flags&WindowManager.LayoutParams.FLAG_SECURE) != 0) {
+//            return true;
+//        }
+//        if (isScreenCaptureDisabledLocked(UserHandle.getUserId(w.mOwnerUid))) {
+//            return true;
+//        }
         return false;
     }
 
@@ -2354,7 +2355,7 @@ public class WindowManagerService extends IWindowManager.Stub
      */
     @Override
     public void setScreenCaptureDisabled(int userId, boolean disabled) {
-        int callingUid = Binder.getCallingUid();
+/*        int callingUid = Binder.getCallingUid();
         if (callingUid != Process.SYSTEM_UID) {
             throw new SecurityException("Only system can call setScreenCaptureDisabled.");
         }
@@ -2371,7 +2372,7 @@ public class WindowManagerService extends IWindowManager.Stub
                     }
                 }
             }
-        }
+        } */
     }
 
     private void setupWindowForRemoveOnExit(WindowState win) {

--- a/services/core/java/com/android/server/wm/WindowStateAnimator.java
+++ b/services/core/java/com/android/server/wm/WindowStateAnimator.java
@@ -1711,10 +1711,10 @@ class WindowStateAnimator {
     }
 
     void setSecureLocked(boolean isSecure) {
-        if (mSurfaceController == null) {
-            return;
-        }
-        mSurfaceController.setSecure(isSecure);
+//        if (mSurfaceController == null) {
+//            return;
+//        }
+//        mSurfaceController.setSecure(isSecure);
     }
 
     // This must be called while inside a transaction.


### PR DESCRIPTION
FLAG_SECURE prevents some applications using it from showing up in anbox.
I think we should disable it for anbox because it just prevents some apps from running
and doesn't offer an actual benefit for us.
Here is a patch for that.